### PR TITLE
Using `NFData` to ensure each step is timed accurately

### DIFF
--- a/app/Ast.hs
+++ b/app/Ast.hs
@@ -1,9 +1,16 @@
+{-# language BangPatterns #-}
+{-# language DeriveGeneric, DeriveAnyClass #-}
 module Ast where
 
-data Value = Int Int
-    | String String
-    | Bool Bool
-    deriving (Eq, Ord, Show)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Generics
+import Control.DeepSeq
+
+data Value = Int {-# UNPACK #-} !Int
+    | String !Text
+    | Bool !Bool
+    deriving (Eq, Ord, Show, Generic, NFData)
 
 data Type = VOID
     | INT
@@ -12,7 +19,7 @@ data Type = VOID
     | BOOL
     | FUNCTION [Type] Type
     | NOTYPE -- When type cannot be inferred
-        deriving (Eq, Show, Ord)
+        deriving (Eq, Show, Ord, Generic, NFData)
 
 -- function add(x: Int, y: Int) -> Int {return x + y}
 -- FUNCTION [INT, INT] INT
@@ -26,10 +33,10 @@ data Type = VOID
 data Stmt = Stmt {
     stmtType :: StmtType,
     stmtPos :: Position
-} deriving (Eq, Ord, Show)
+} deriving (Eq, Ord, Show, Generic, NFData)
 
-data FuncCase = FuncCase [(String, Maybe Exp)] [Stmt] deriving (Eq, Ord, Show)
-data TFuncCase = TFuncCase [(String, Maybe TExp)] [TStmt] deriving (Eq, Ord, Show)
+data FuncCase = FuncCase [(String, Maybe Exp)] [Stmt] deriving (Eq, Ord, Show, Generic, NFData)
+data TFuncCase = TFuncCase [(String, Maybe TExp)] [TStmt] deriving (Eq, Ord, Show, Generic, NFData)
 
 data StmtType = VarAssign String Exp
     | LetAssign String Exp
@@ -39,13 +46,13 @@ data StmtType = VarAssign String Exp
     | While Exp [Stmt]
     | FuncDef String [(String, Type)] Type [FuncCase]
     | ReturnStmt Exp
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic, NFData)
 
 
 data TStmt = TStmt {
     tStmtType :: TStmtType,
     tStmtPos :: Position
-} deriving (Eq, Ord, Show)
+} deriving (Eq, Ord, Show, Generic, NFData)
 
 data TStmtType = TVarAssign String TExp
     | TLetAssign String TExp
@@ -55,15 +62,15 @@ data TStmtType = TVarAssign String TExp
     | TWhile TExp [TStmt]
     | TFuncDef String [(String, Type)] Type [TFuncCase]
     | TReturnStmt TExp
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic, NFData)
 
 type AST = [Stmt]
 type TAST = [TStmt]
 
 data Position = Position {
-    posOffset :: Int,
-    posLength :: Int
-} deriving (Eq, Ord, Show)
+    posOffset :: {-# UNPACK #-} !Int,
+    posLength :: {-# UNPACK #-} !Int
+} deriving (Eq, Ord, Show, Generic, NFData)
 
 posInit :: Position
 posInit = Position 0 0
@@ -72,7 +79,7 @@ data TExp = TExp {
     tExp :: TExpType,
     tExpPos :: Position,
     tExpType :: Type
-} deriving (Eq, Ord, Show)
+} deriving (Eq, Ord, Show, Generic, NFData)
 
 data TExpType = TAdd TExp TExp
     | TSub TExp TExp
@@ -92,12 +99,12 @@ data TExpType = TAdd TExp TExp
     | TLambda [(String, Position)] TExp
     | TIf TExp TExp TExp
     | TAnyExp -- For type failures
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic, NFData)
 
 data Exp = Exp {
     expType :: ExpType,
     expPos :: Position
-} deriving (Eq, Ord, Show)
+} deriving (Eq, Ord, Show, Generic, NFData)
 
 data ExpType = Add Exp Exp
     | Sub Exp Exp
@@ -117,4 +124,4 @@ data ExpType = Add Exp Exp
     | Lambda [(String, Position)] Exp
     | If Exp Exp Exp
     | StaticType Exp
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic, NFData)

--- a/app/CompilerError.hs
+++ b/app/CompilerError.hs
@@ -31,8 +31,8 @@ resultTypeToDiagnose :: CompileResultType
     -> [(E.Position, Marker String)]
     -> [Note String]
     -> Report String
-resultTypeToDiagnose CompileError = err
-resultTypeToDiagnose CompileWarning = warn
+resultTypeToDiagnose CompileError = Error.Diagnose.Err
+resultTypeToDiagnose CompileWarning = Error.Diagnose.Warn
 
 beautifyCompileResult :: CompileResult a => a -> Report String
 beautifyCompileResult r =

--- a/app/Parser.hs
+++ b/app/Parser.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Parser where
 
+import GHC.Generics
 import Text.Megaparsec
 import Text.Megaparsec.Char
+import qualified Data.Text as Text
 import qualified Text.Megaparsec.Char.Lexer as L
 import Data.Void (Void)
 import Data.Functor
@@ -14,6 +18,7 @@ import Data.Maybe (fromJust)
 import Debug.Trace
 import Control.Monad
 import Data.List (singleton)
+import Control.DeepSeq
 
 data ErrType = NoTypeForParam String
     | TrailingCommaInFuncArgs
@@ -22,10 +27,10 @@ data ErrType = NoTypeForParam String
     | NoClosingBrace
     | NoCommaBeforeParam
     | ConditionNotSupplied String
-    deriving (Eq, Show, Ord)
+    deriving (Eq, Show, Ord, Generic, NFData)
 
 data Err = Err {errType :: ErrType, errLength :: Int}
-    deriving (Eq, Show, Ord)
+    deriving (Eq, Show, Ord, Generic, NFData)
 
 throwError :: Int -> ErrType -> Int -> Parser ()
 throwError o t n = registerParseError (FancyError o (E.singleton (ErrorCustom $ Err t n)))
@@ -66,7 +71,7 @@ parseBool = (string "True" $> True) <|> (string "False" $> False)
 
 parseValue :: Parser Value
 parseValue = Int <$> parseInt
-    <|> String <$> parseString
+    <|> String . Text.pack <$> parseString
     <|> Bool <$> parseBool
 
 parseWithPos :: Parser (Position -> a) -> Parser a

--- a/app/Typechecker.hs
+++ b/app/Typechecker.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 {-# HLINT ignore "Use tuple-section" #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Typechecker (
     TypeError(..),
@@ -12,6 +13,7 @@ module Typechecker (
     typecheck''
 ) where
 
+import qualified Data.Text as Text
 import Ast
 import Control.Monad
 import Control.Applicative
@@ -552,7 +554,7 @@ typecheckStmt' stmt = (\v -> v >>= \v -> return $ TStmt v stmt.stmtPos) <$> case
             Nothing -> do
                 addError (TypeError UnexpectedReturnStmt stmt.stmtPos [])
                 return $ Just (TReturnStmt (tAnyExpWrapper exp))
-    s -> error (show s)
+    -- s -> error (show s)
 
 inferBinaryIntOp :: Exp -> Exp -> (TExp -> TExp -> TExpType) -> String -> TypeChecker (Maybe (TExpType, Type))
 inferBinaryIntOp x y t s = do
@@ -613,7 +615,7 @@ inferExp exp = (>>= \(v, t') -> return $ TExp v exp.expPos t') <$> case exp.expT
             _ -> return Nothing
     StaticType exp -> do
         x <- inferExp exp
-        return (x <&> \x -> (TVal (String (show x.tExpType)), STRING))
+        return (x <&> \x -> (TVal (String (Text.pack $ show x.tExpType)), STRING))
     CallFunc exp exps -> do
         x <- inferExp exp
         case x of
@@ -837,7 +839,7 @@ typecheckExp' exp t = (\(v, t') -> TExp v exp.expPos t') <$> case exp.expType of
         return (TIf cond' a b, a.tExpType)
     StaticType exp -> do
         x <- typecheckExp' exp Nothing
-        return (TVal (String (show x.tExpType)), STRING)
+        return (TVal (String (Text.pack $ show x.tExpType)), STRING)
     x -> error $ "couldn't typecheck: " ++ show x
 
 valueIsOfType :: Value -> Type -> Bool

--- a/bytecode-compiler.cabal
+++ b/bytecode-compiler.cabal
@@ -47,10 +47,13 @@ executable bytecode-compiler
         vector,
         containers,
         text,
+        clock,
         diagnose,
         mtl,
-        ansi-terminal
+        ansi-terminal,
+        deepseq,
     hs-source-dirs:   app
+    default-extensions: StrictData, DeriveGeneric, DeriveAnyClass
     default-language: Haskell2010
     -- ghc-options: -O2
         -- -fprof-auto


### PR DESCRIPTION
This PR adds `NFData` derivation and a simple `timed` utility to measure the time taken in each step. 

Building with optimizations, I get these numbers:

```
$ time cabal run bytecode-compiler "test.txt"
Warning: Both /home/matt/.cabal and /home/matt/.config/cabal/config exist -
ignoring the former.
It is advisable to remove one of them. In that case, we will use the remaining
one by default (unless '$CABAL_DIR' is explicitly set).
("parseProgram Action took: ",223," milliseconds")
("typecheck'' Action took: ",56," milliseconds")
("compileProgram Action took: ",59," milliseconds")
55
("runExecProgram Action took: ",276," milliseconds")
("main Action took: ",695," milliseconds")
```

Parsing is taking about half the time of execution. I suspect you could get a huge speedup here by using the `Data.Text` file IO and parsing `Text` instead of `String`.

Profiling this version of the code should help you identify what part of `runExecProgram` is actually taking a lot of time.